### PR TITLE
Switch to v3 of slack action

### DIFF
--- a/.github/workflows/go-ci.yaml
+++ b/.github/workflows/go-ci.yaml
@@ -85,11 +85,11 @@ jobs:
         version: latest
     - name: Send to Slack
       if: ${{ failure() && env.HAS_SLACK_FAILURE_WEBHOOK_URL == 'true' }}
-      uses: slackapi/slack-github-action@v1.27.0
+      uses: slackapi/slack-github-action@v3
       with:
+        webhook-type: webhook-trigger
+        webhook: ${{ secrets.SLACK_FAILURE_WEBHOOK_URL }}
         payload: |
           {
           "run_url": "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
           }
-      env:
-        SLACK_WEBHOOK_URL: ${{ secrets.SLACK_FAILURE_WEBHOOK_URL }}


### PR DESCRIPTION
Still produces a warning, but I don't think it is something we should care about.
```
Run slackapi/slack-github-action@v3
(node:5329) [DEP0169] DeprecationWarning: `url.parse()` behavior is not standardized and prone to errors that have security implications. Use the WHATWG URL API instead. CVEs are not issued for `url.parse()` vulnerabilities.
(Use `node --trace-deprecation ...` to show where the warning was created)
```

It is a known issue and should be fixed eventually:  https://github.com/slackapi/slack-github-action/issues/580.